### PR TITLE
Fix calling animationModule in ISP bad example（same fix as original repository）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1795,7 +1795,7 @@ class DOMTraverser {
 
   setup() {
     this.rootNode = this.settings.rootNode;
-    this.animationModule.setup();
+    this.settings.animationModule.setup();
   }
 
   traverse() {


### PR DESCRIPTION
Fix calling animationModule in ISP bad example.
It is same fix as original repository's PR (https://github.com/ryanmcdermott/clean-code-javascript/pull/312).